### PR TITLE
**Updated:** .vsix Manifest file to allow Extension to be compatible with VS 2019.

### DIFF
--- a/Neo4JConsolePackage/source.extension.vsixmanifest
+++ b/Neo4JConsolePackage/source.extension.vsixmanifest
@@ -21,6 +21,6 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[11.0,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[11.0,17.0)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
I've had a look into this one and I believe these changes should allow the Extension to work with Visual Studio 2019.

Original issue: [Issue #2 - Visual Studio 2019](https://github.com/DotNet4Neo4j/Neo4j-Vs-Console/issues/2)

This involved a minor update to the Manifest file which updates the Version Range for the '**Microsoft.VisualStudio.Component.CoreEditor**' prerequisite.

Hope this helps!